### PR TITLE
change default interval to 10 so that gifs play in real time

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ crw-rw----    1 root     root       29,   0 Jan  1  1970 /dev/fb0
 5. Run the example on your embedded device:
 
 ```bash
-fba --device /dev/fb0 --interval 5 --once --center /root/images/spaceship-640x480.gif
+fba --device /dev/fb0 --interval 10 --once --center /root/images/spaceship-640x480.gif
 ```
 
 Enjoy your GIF animations on your embedded display!
@@ -98,7 +98,7 @@ The Framebuffer Animations accepts the following command line arguments:
 
 - `--device`, `-d`: Specifies the framebuffer device file. Default is `/dev/fb0`.
 
-- `--interval`, `-i`: Sets the interval step for displaying GIF frames in milliseconds. Default is 5 milliseconds.
+- `--interval`, `-i`: Sets the interval step for displaying GIF frames in milliseconds. Default is 10 milliseconds.
 
 - `--once`, `-o`: When provided, the GIF animation will play only one time. By default, it loops indefinitely.
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,7 +18,7 @@ FLAGS:
 
 OPTIONS:
   -d, --device DEVICE       Framebuffer device file [default: /dev/fb0]
-  -i, --interval NUMBER     Interval step for displaying GIF frames (milliseconds) [default: 5]
+  -i, --interval NUMBER     Interval step for displaying GIF frames (milliseconds) [default: 10]
   -o, --once                Play the file just one time
   -c, --center              Center the GIF
 
@@ -61,7 +61,7 @@ fn parse_args() -> Result<Args, pico_args::Error> {
 
     let args = Args {
         device: pargs.opt_value_from_str(["-d", "--device"])?.unwrap_or("/dev/fb0".to_string()),
-        interval: pargs.opt_value_from_fn(["-i", "--interval"], parse_interval)?.unwrap_or(5),
+        interval: pargs.opt_value_from_fn(["-i", "--interval"], parse_interval)?.unwrap_or(10),
         once: pargs.contains(["-o", "--once"]),
         center: pargs.contains(["-c", "--center"]),
         gif_file: pargs.free_from_str()?,


### PR DESCRIPTION
hello,

thank you for your tool, I enjoyed playing around with it. I found that my gif played 2x as fast as I expected it to play. The reason for that is because gif frame delay returns a value in ten milliseconds increments. Changing the default would make the default gif speed the intended speed.